### PR TITLE
Set $multipage to 0 when viewing all

### DIFF
--- a/view-all-posts-pages.php
+++ b/view-all-posts-pages.php
@@ -179,7 +179,7 @@ class view_all_posts_pages {
 	 */
 	public function action_the_post( $post ) {
 		if ( $this->is_view_all() ) {
-			global $pages, $more;
+			global $pages, $more, $multipage;
 
 			$post->post_content = str_replace( "\n<!--nextpage-->\n", "\n\n", $post->post_content );
 			$post->post_content = str_replace( "\n<!--nextpage-->", "\n", $post->post_content );
@@ -189,6 +189,7 @@ class view_all_posts_pages {
 			$pages = array( $post->post_content );
 
 			$more = 1;
+			$multipage = 0;
 		}
 	}
 


### PR DESCRIPTION
This way, wp_list_pages will not output next/previous pages.
